### PR TITLE
services: Increase heartbeat max transitions

### DIFF
--- a/packages/services/src/workers/heartbeat.js
+++ b/packages/services/src/workers/heartbeat.js
@@ -5,7 +5,7 @@ import Network from '@aragon/court-backend-server/build/web3/Network'
 const { ErrorLog } = Models
 
 const SECONDS_BETWEEN_INTENTS = 3
-const MAX_TRANSITIONS_PER_CALL = 10
+const MAX_TRANSITIONS_PER_CALL = 20
 
 export default async function (worker, job, tries, logger) {
   try {

--- a/packages/services/src/workers/heartbeat.js
+++ b/packages/services/src/workers/heartbeat.js
@@ -5,7 +5,7 @@ import Network from '@aragon/court-backend-server/build/web3/Network'
 const { ErrorLog } = Models
 
 const SECONDS_BETWEEN_INTENTS = 3
-const MAX_TRANSITIONS_PER_CALL = 2
+const MAX_TRANSITIONS_PER_CALL = 10
 
 export default async function (worker, job, tries, logger) {
   try {


### PR DESCRIPTION
10 transitions is still a safe value (see here an example, using ~500k
gas:
https://rinkeby.etherscan.io/tx/0x095f553bd9a168ca67c18718022303b1b807b9b3ecd0f0c2cabf6a774c23ddcc),
and allows to catch up faster if the Court clock lags behind.