### PR TITLE
Server: samesite cookie fix

### DIFF
--- a/packages/server/src/helpers/session-middleware.js
+++ b/packages/server/src/helpers/session-middleware.js
@@ -60,6 +60,8 @@ export default () => {
       secure: process.env.SESSION_SECURE === 'true',    // Compliant clients will not send the cookie back to the server if the browser does not have an HTTPS connection
       maxAge: SESSION_MAXAGE,                           // The maximum age in milliseconds of a valid session
       httpOnly: true,                                   // Request cookies only to be used for http communication
+      sameSite: 'none',                                 // must set samesite: none with secure for Chrome 80+:
+      secure: true                                      // https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
     }
   })
 }

--- a/packages/server/src/helpers/session-middleware.js
+++ b/packages/server/src/helpers/session-middleware.js
@@ -57,11 +57,10 @@ export default () => {
     secret: process.env.SESSION_SECRET,                 // Secret used to generate session IDs
     name: 'aragonCourtSessionID',                       // Cookie name to be used
     cookie: {
+      sameSite: 'none',                                 // Must set Samesite=None for cross-site cookies for Chrome 80+
       secure: process.env.SESSION_SECURE === 'true',    // Compliant clients will not send the cookie back to the server if the browser does not have an HTTPS connection
       maxAge: SESSION_MAXAGE,                           // The maximum age in milliseconds of a valid session
       httpOnly: true,                                   // Request cookies only to be used for http communication
-      sameSite: 'none',                                 // must set samesite: none with secure for Chrome 80+:
-      secure: true                                      // https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
     }
   })
 }


### PR DESCRIPTION
Need to add `SameSite=None; Secure` for Chrome 80+
https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
(this is not related to Brave browser problem)