### PR TITLE
Notifications service: reduced scan period for DueTasks scanner

### DIFF
--- a/packages/services/src/models/notification-scanners/DueTasks.js
+++ b/packages/services/src/models/notification-scanners/DueTasks.js
@@ -74,7 +74,7 @@ class DueTasks extends NotificationScannerBaseModel {
   }
 
   get emailTemplateAlias() { return 'due-tasks' }
-  get scanPeriod() { return this._DAYS }
+  get scanPeriod() { return this._MINUTES }
 }
 
 export default new DueTasks()


### PR DESCRIPTION
If we only scan once per day we can miss shorter periods on testnets