### PR TITLE
Emails: minor language fixes

### DIFF
--- a/emails/template-utils.js
+++ b/emails/template-utils.js
@@ -1075,6 +1075,18 @@ function dataTable(listName, headers) {
   `
 }
 
+function textFooter() {
+  return `
+    This service is provided by Aragon One AG [1]. You are receiving this email
+    because you are subscribed to Aragon Court Email Notifications. To modify 
+    your email notification settings, visit the Notifications section [2] of
+    the Court Dashboard Settings
+
+    [1] https://aragon.one/
+    [2] https://court.aragon.org/dashboard?preferences=notifications
+  `
+}
+
 module.exports = {
   action,
   addressBadge,
@@ -1090,4 +1102,5 @@ module.exports = {
   table,
   trimMultiline,
   vspace,
+  textFooter
 }

--- a/emails/templates/appeals-opened.js
+++ b/emails/templates/appeals-opened.js
@@ -10,7 +10,7 @@ const { accountData } = require('../helpers')
 
 module.exports = function() {
   return {
-    subject: 'Appeals are open for Dispute {{disputeId}}',
+    subject: 'Appeals are open for Dispute #{{disputeId}}',
     template: base(
       {
         title: 'Notifications',
@@ -20,20 +20,20 @@ module.exports = function() {
         ${infobox({
           mode: 'appeals-opened',
           primary: `
-            Appeals are now open for a Preliminary Ruling of ${link(
+            Appeals are now open for a preliminary ruling of ${link(
               'Dispute #{{disputeId}}',
               '{{disputeUrl}}',
               { nowrap: true }
             )}`,
           secondary: trimMultiline(`
-            Now that Voting has ended, Preliminary Rulings can be appealed by
+            Now that voting has ended, preliminary rulings can be appealed by
             anyone, including you. If you disagree with the ruling made by your
             fellow jurors and believe it will be overturned by a larger set of
             jurors, you can appeal the dispute and earn a reward if your appeal
             is successful.
           `),
         })}
-        ${action('Appeal Ruling', '{{disputeUrl}}', {
+        ${action('Appeal ruling', '{{disputeUrl}}', {
           padding: '16px 0 0',
         })}
       `
@@ -43,15 +43,15 @@ module.exports = function() {
 
       Your account {{account}} received a notification on {{date}}:
 
-      Appeals are now open for a Preliminary Ruling of Dispute #{{disputeId}}.
+      Appeals are now open for a preliminary ruling of Dispute #{{disputeId}}.
 
-      Now that Voting has ended, Preliminary Rulings can be appealed by
+      Now that voting has ended, preliminary rulings can be appealed by
       anyone, including you. If you disagree with the ruling made by your
       fellow jurors and believe it will be overturned by a larger set of
       jurors, you can appeal the dispute and earn a reward if your appeal
       is successful.
 
-      Appeal Ruling: {{disputeUrl}}
+      Appeal ruling: {{disputeUrl}}
 
       This service is provided by Aragon One AG [1]. You are receiving this email
       because you are subscribed to Aragon Court Email Notifications. You can

--- a/emails/templates/appeals-opened.js
+++ b/emails/templates/appeals-opened.js
@@ -5,6 +5,7 @@ const {
   infobox,
   link,
   trimMultiline,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -52,12 +53,7 @@ module.exports = function() {
       is successful.
 
       Appeal ruling: {{disputeUrl}}
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/drafted.js
+++ b/emails/templates/drafted.js
@@ -4,6 +4,7 @@ const {
   base,
   infobox,
   link,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -41,12 +42,7 @@ module.exports = function() {
       reviewing the arguments and then commit your vote.
 
       Review the arguments and vote: {{disputeUrl}}
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/drafted.js
+++ b/emails/templates/drafted.js
@@ -25,9 +25,9 @@ module.exports = function() {
               { nowrap: true }
             )}`,
           secondary:
-            'You can start reviewing the evidence and then commit your vote',
+            'You can start reviewing the arguments and then commit your vote',
         })}
-        ${action('Start reviewing evidence', '{{disputeUrl}}', {
+        ${action('Review the arguments and vote', '{{disputeUrl}}', {
           padding: '16px 0 0',
         })}
       `
@@ -38,9 +38,9 @@ module.exports = function() {
       Your account {{account}} received a notification on {{date}}:
 
       You have been selected to arbitrate Dispute #{{disputeId}}. You can start
-      reviewing the evidence and then commit your vote.
+      reviewing the arguments and then commit your vote.
 
-      Start reviewing evidence: {{disputeUrl}}
+      Review the arguments and vote: {{disputeUrl}}
 
       This service is provided by Aragon One AG [1]. You are receiving this email
       because you are subscribed to Aragon Court Email Notifications. You can

--- a/emails/templates/drafted.js
+++ b/emails/templates/drafted.js
@@ -9,7 +9,7 @@ const { accountData } = require('../helpers')
 
 module.exports = function() {
   return {
-    subject: 'You have been selected to arbitrate Dispute {{disputeId}} on Aragon Court',
+    subject: 'You have been selected to arbitrate Dispute #{{disputeId}} on Aragon Court',
     template: base(
       {
         title: 'Notifications',

--- a/emails/templates/due-tasks.js
+++ b/emails/templates/due-tasks.js
@@ -29,7 +29,7 @@ module.exports = function() {
       `
     ),
     templateText: `
-      Aragon Court Notifications
+      Aragon Court Task Reminder
 
       You have tasks due soon:
       {{#each tasks}}

--- a/emails/templates/due-tasks.js
+++ b/emails/templates/due-tasks.js
@@ -4,6 +4,7 @@ const {
   dataTable,
   link,
   vspace,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -38,12 +39,7 @@ module.exports = function() {
       Due date: {{dueDate}}
       Address: {{disputeUrl}}
       {{/each}}
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/email-verification-reminder.js
+++ b/emails/templates/email-verification-reminder.js
@@ -1,4 +1,10 @@
-const { action, base, link, vspace } = require('../template-utils')
+const {
+  action,
+  base,
+  link,
+  vspace,
+  textFooter
+} = require('../template-utils')
 
 module.exports = function() {
   return {
@@ -49,6 +55,7 @@ module.exports = function() {
       2) go to your notification settings (top right)
       3) click “Resend verification email”
       {{emailPreferencesUrl}}
+      ${textFooter()}
     `,
     mockData: {
       emailPreferencesUrl:

--- a/emails/templates/email-verification-reminder.js
+++ b/emails/templates/email-verification-reminder.js
@@ -5,7 +5,7 @@ module.exports = function() {
     subject: 'Aragon Court email verification reminder',
     template: base(
       {
-        title: 'Email Verification Reminder',
+        title: 'Notifications',
         subtitle: `
           Verify your email to receive email notifications about important news
           and upcoming tasks.
@@ -22,8 +22,8 @@ module.exports = function() {
         <div style="font-size:16px;line-height:24px;color:#212B36">
           To do so, please click on the button below and 
           1) connect your account 
-          2) go to your notifications settings (top right)
-          3) click Resend verification email
+          2) go to your notification settings (top right)
+          3) click “Resend verification email”
         </div>
 
         ${vspace(40)}
@@ -39,15 +39,15 @@ module.exports = function() {
       `
     ),
     templateText: `
-      Email Verification
+      Aragon Court Notifications
 
       You recently subscribed to Aragon Court email notifications, but did not
       complete the email verification process.
 
       To do so, please copy and paste this URL into your browser and 
       1) connect your account 
-      2) go to your notifications settings (top right)
-      3) click Resend verification email
+      2) go to your notification settings (top right)
+      3) click “Resend verification email”
       {{emailPreferencesUrl}}
     `,
     mockData: {

--- a/emails/templates/email-verification.js
+++ b/emails/templates/email-verification.js
@@ -1,4 +1,10 @@
-const { action, base, link, vspace } = require('../template-utils')
+const {
+  action,
+  base,
+  link,
+  vspace,
+  textFooter
+} = require('../template-utils')
 
 module.exports = function() {
   return {
@@ -41,6 +47,7 @@ module.exports = function() {
 
       Verify your email by copying and pasting this URL into your browser:
       {{verifyEmailUrl}}
+      ${textFooter()}
     `,
     mockData: {
       verifyEmailUrl:

--- a/emails/templates/email-verification.js
+++ b/emails/templates/email-verification.js
@@ -5,7 +5,7 @@ module.exports = function() {
     subject: 'Verify your email on Aragon Court',
     template: base(
       {
-        title: 'Email Verification',
+        title: 'Notifications',
         subtitle: `
           Verify your email to receive email notifications about important news
           and upcoming tasks.
@@ -31,7 +31,7 @@ module.exports = function() {
       `
     ),
     templateText: `
-      Email Verification
+      Aragon Court Notifications
 
       Verify your email to receive email notifications about important news
       and upcoming tasks.

--- a/emails/templates/generic-action.js
+++ b/emails/templates/generic-action.js
@@ -5,6 +5,7 @@ const {
   infobox,
   link,
   trimMultiline,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -36,12 +37,7 @@ module.exports = function() {
       {{actionText}}
 
       Go to dashboard: https://court.aragon.org
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/generic-notification.js
+++ b/emails/templates/generic-notification.js
@@ -6,6 +6,7 @@ const {
   style,
   table,
   trimMultiline,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -63,12 +64,7 @@ module.exports = function() {
       {{content}}
 
       {{actionLabel}}: {{actionUrl}}
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/generic-warning.js
+++ b/emails/templates/generic-warning.js
@@ -4,6 +4,7 @@ const {
   base2,
   button,
   trimMultiline,
+  textFooter
 } = require('../template-utils')
 
 module.exports = function() {
@@ -37,12 +38,7 @@ module.exports = function() {
       {{content}}
 
       {{actionLabel}}: {{actionUrl}}
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       actionLabel: 'Try the Playground',

--- a/emails/templates/generic.js
+++ b/emails/templates/generic.js
@@ -4,6 +4,7 @@ const {
   base2,
   button,
   trimMultiline,
+  textFooter
 } = require('../template-utils')
 
 module.exports = function() {
@@ -31,12 +32,7 @@ module.exports = function() {
       {{content}}
 
       {{actionLabel}}: {{actionUrl}}
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       actionLabel: 'New Campaign Details >>',

--- a/emails/templates/missed-reveal.js
+++ b/emails/templates/missed-reveal.js
@@ -36,18 +36,19 @@ module.exports = function() {
 
       Your account {{account}} received a notification on {{date}}:
 
-      Your vote wasn’t revealed on time. Some of your locked ANJ [1] balance has
-      been forfeit.
+      Your vote wasn’t revealed on time for Dispute #{{disputeId}} [1]. 
+      Some of your locked ANJ [2] balance has been forfeit.
 
       Learn more: https://help.aragon.org/article/43-dispute-lifecycle#vote-reveal
 
-      This service is provided by Aragon One AG [2]. You are receiving this
+      This service is provided by Aragon One AG [3]. You are receiving this
       email because you are subscribed to Aragon Court Email Notifications. You
       can contact us at support@aragon.org if you not longer wish to receive
       these.
 
-      [1] {{lockedAnjBalanceUrl}}
-      [2] https://aragon.one/
+      [1] {{disputeUrl}}
+      [2] {{lockedAnjBalanceUrl}}
+      [3] https://aragon.one/
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/missed-reveal.js
+++ b/emails/templates/missed-reveal.js
@@ -4,6 +4,7 @@ const {
   base,
   infobox,
   link,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -36,19 +37,11 @@ module.exports = function() {
 
       Your account {{account}} received a notification on {{date}}:
 
-      Your vote wasn’t revealed on time for Dispute #{{disputeId}} [1]. 
-      Some of your locked ANJ [2] balance has been forfeit.
+      Your vote wasn’t revealed on time for Dispute #{{disputeId}}.
+      Some of your locked ANJ balance has been forfeit.
 
       Learn more: https://help.aragon.org/article/43-dispute-lifecycle#vote-reveal
-
-      This service is provided by Aragon One AG [3]. You are receiving this
-      email because you are subscribed to Aragon Court Email Notifications. You
-      can contact us at support@aragon.org if you not longer wish to receive
-      these.
-
-      [1] {{disputeUrl}}
-      [2] {{lockedAnjBalanceUrl}}
-      [3] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/missed-vote.js
+++ b/emails/templates/missed-vote.js
@@ -36,18 +36,19 @@ module.exports = function() {
 
       Your account {{account}} received a notification on {{date}}:
 
-      Your vote wasn’t cast on time. Some of your locked ANJ [1] balance has
-      been forfeit.
+      Your vote wasn’t cast on time for Dispute #{{disputeId}} [1]. 
+      Some of your locked ANJ [2] balance has been forfeit.
 
       Learn more: https://help.aragon.org/article/43-dispute-lifecycle#voting-period
 
-      This service is provided by Aragon One AG [2]. You are receiving this
+      This service is provided by Aragon One AG [3]. You are receiving this
       email because you are subscribed to Aragon Court Email Notifications. You
       can contact us at support@aragon.org if you not longer wish to receive
       these.
 
-      [1] {{lockedAnjBalanceUrl}}
-      [2] https://aragon.one/
+      [1] {{disputeUrl}}
+      [2] {{lockedAnjBalanceUrl}}
+      [3] https://aragon.one/
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/missed-vote.js
+++ b/emails/templates/missed-vote.js
@@ -4,6 +4,7 @@ const {
   base,
   infobox,
   link,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -36,19 +37,11 @@ module.exports = function() {
 
       Your account {{account}} received a notification on {{date}}:
 
-      Your vote wasn’t cast on time for Dispute #{{disputeId}} [1]. 
-      Some of your locked ANJ [2] balance has been forfeit.
+      Your vote wasn’t cast on time for Dispute #{{disputeId}}. 
+      Some of your locked ANJ balance has been forfeit.
 
       Learn more: https://help.aragon.org/article/43-dispute-lifecycle#voting-period
-
-      This service is provided by Aragon One AG [3]. You are receiving this
-      email because you are subscribed to Aragon Court Email Notifications. You
-      can contact us at support@aragon.org if you not longer wish to receive
-      these.
-
-      [1] {{disputeUrl}}
-      [2] {{lockedAnjBalanceUrl}}
-      [3] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/notification-settings-announcement.js
+++ b/emails/templates/notification-settings-announcement.js
@@ -14,7 +14,7 @@ module.exports = function() {
       },
       `
         <div style="font-size:16px;line-height:24px;color:#212B36">
-          You can now modify your email notification settings by visiting the Aragon Court Dashboard and connecting your Ethereum account
+          You can now modify your email notification settings by visiting the Aragon Court Dashboard and connecting your Ethereum account.
         </div>
 
         ${vspace(20)}
@@ -29,9 +29,11 @@ module.exports = function() {
       `
     ),
     templateText: `
+      Aragon Court Notification Settings
+
       You have received this email because you provided your email on anj.aragon.org.
 
-      You can now modify your email notification settings by visiting the Aragon Court Dashboard and connecting your Ethereum account
+      You can now modify your email notification settings by visiting the Aragon Court Dashboard and connecting your Ethereum account.
 
       To do so, please copy and paste this URL into your browser and follow the instructions:
       {{dashboardUrl}}

--- a/emails/templates/notification-settings-announcement.js
+++ b/emails/templates/notification-settings-announcement.js
@@ -1,7 +1,8 @@
 const {
   action,
   base,
-  vspace
+  vspace,
+  textFooter
 } = require('../template-utils')
 
 module.exports = function() {
@@ -37,6 +38,7 @@ module.exports = function() {
 
       To do so, please copy and paste this URL into your browser and follow the instructions:
       {{dashboardUrl}}
+      ${textFooter()}
     `,
     mockData: {
       dashboardUrl: 'https://court.aragon.org/dashboard',

--- a/emails/templates/ruled.js
+++ b/emails/templates/ruled.js
@@ -9,7 +9,7 @@ const { accountData } = require('../helpers')
 
 module.exports = function() {
   return {
-    subject: 'Dispute {{disputeId}} has been ruled as “{{disputeResult}}”',
+    subject: 'The final ruling in Dispute #{{disputeId}} is “{{disputeResult}}”',
     template: base(
       {
         title: 'Notifications',
@@ -18,13 +18,14 @@ module.exports = function() {
       `
         ${infobox({
           mode: 'positive',
-          primary: `
-            ${link('Dispute #{{disputeId}}', '{{disputeUrl}}', {
-              nowrap: true,
-            })} has been ruled as “{{disputeResult}}”`,
-          secondary: 'You can see the final result and claim any rewards',
+          primary: `The final ruling in ${link(
+            'Dispute #{{disputeId}}',
+            '{{disputeUrl}}',
+            { nowrap: true }
+          )} has been ruled as “{{disputeResult}}”`,
+          secondary: 'You can now see the final ruling and claim your rewards',
         })}
-        ${action('See result', '{{disputeUrl}}', {
+        ${action('See final ruling', '{{disputeUrl}}', {
           padding: '16px 0 0',
         })}
       `
@@ -34,10 +35,10 @@ module.exports = function() {
 
       Your account {{account}} received a notification on {{date}}:
 
-      Dispute #{{disputeId}} has been ruled as {{disputeResult}}. You can see
-      the final result and claim any rewards.
+      The final ruling in Dispute #{{disputeId}} is “{{disputeResult}}”. 
+      You can now see the final ruling and claim your rewards.
 
-      See result: {{disputeUrl}}
+      See final ruling: {{disputeUrl}}
 
       This service is provided by Aragon One AG [1]. You are receiving this email
       because you are subscribed to Aragon Court Email Notifications. You can

--- a/emails/templates/ruled.js
+++ b/emails/templates/ruled.js
@@ -22,7 +22,7 @@ module.exports = function() {
             'Dispute #{{disputeId}}',
             '{{disputeUrl}}',
             { nowrap: true }
-          )} has been ruled as “{{disputeResult}}”`,
+          )} is “{{disputeResult}}”`,
           secondary: 'You can now see the final ruling and claim your rewards',
         })}
         ${action('See final ruling', '{{disputeUrl}}', {

--- a/emails/templates/ruled.js
+++ b/emails/templates/ruled.js
@@ -4,6 +4,7 @@ const {
   base,
   infobox,
   link,
+  textFooter
 } = require('../template-utils')
 const { accountData } = require('../helpers')
 
@@ -39,12 +40,7 @@ module.exports = function() {
       You can now see the final ruling and claim your rewards.
 
       See final ruling: {{disputeUrl}}
-
-      This service is provided by Aragon One AG [1]. You are receiving this email
-      because you are subscribed to Aragon Court Email Notifications. You can
-      contact us at support@aragon.org if you not longer wish to receive these.
-
-      [1] https://aragon.one/
+      ${textFooter()}
     `,
     mockData: {
       ...accountData('0xef0f7ecef8385483ac8a2e92d761f571c4b782bd'),

--- a/emails/templates/ruled.js
+++ b/emails/templates/ruled.js
@@ -9,7 +9,7 @@ const { accountData } = require('../helpers')
 
 module.exports = function() {
   return {
-    subject: 'The final ruling in Dispute #{{disputeId}} is “{{disputeResult}}”',
+    subject: 'The final ruling for Dispute #{{disputeId}} is “{{disputeResult}}”',
     template: base(
       {
         title: 'Notifications',
@@ -18,7 +18,7 @@ module.exports = function() {
       `
         ${infobox({
           mode: 'positive',
-          primary: `The final ruling in ${link(
+          primary: `The final ruling for ${link(
             'Dispute #{{disputeId}}',
             '{{disputeUrl}}',
             { nowrap: true }
@@ -35,7 +35,7 @@ module.exports = function() {
 
       Your account {{account}} received a notification on {{date}}:
 
-      The final ruling in Dispute #{{disputeId}} is “{{disputeResult}}”. 
+      The final ruling for Dispute #{{disputeId}} is “{{disputeResult}}”. 
       You can now see the final ruling and claim your rewards.
 
       See final ruling: {{disputeUrl}}

--- a/packages/services/src/models/notification-scanners/DisputeRuled.js
+++ b/packages/services/src/models/notification-scanners/DisputeRuled.js
@@ -3,9 +3,9 @@ import Network from '@aragonone/court-backend-server/build/web3/Network'
 const OUTCOMES = {
   0: 'Missing',
   1: 'Leaked',
-  2: 'Refused',
-  3: 'Against',
-  4: 'InFavor',
+  2: 'Refuse to vote',
+  3: 'Block',
+  4: 'Allow',
 }
 
 class DisputeRuled extends NotificationScannerBaseModel {

--- a/packages/services/src/models/notification-scanners/DisputeRuled.js
+++ b/packages/services/src/models/notification-scanners/DisputeRuled.js
@@ -3,9 +3,9 @@ import Network from '@aragonone/court-backend-server/build/web3/Network'
 const OUTCOMES = {
   0: 'Missing',
   1: 'Leaked',
-  2: 'Refuse to vote',
-  3: 'Block',
-  4: 'Allow',
+  2: 'Refused to vote',
+  3: 'Blocked',
+  4: 'Allowed',
 }
 
 class DisputeRuled extends NotificationScannerBaseModel {

--- a/packages/services/test/integration/notification-scanners/DisputeRuled.js
+++ b/packages/services/test/integration/notification-scanners/DisputeRuled.js
@@ -69,7 +69,7 @@ describe('DisputeRuled notifications', () => {
       emailTemplateModel: {
         disputeId: TEST_DISPUTE_ID,
         disputeUrl: `${CLIENT_URL}disputes/${TEST_DISPUTE_ID}`,
-        disputeResult: 'InFavor'
+        disputeResult: 'Allow'
       }
     })
     expect(ctx.logger.success).to.have.callCount(1)

--- a/packages/services/test/integration/notification-scanners/DisputeRuled.js
+++ b/packages/services/test/integration/notification-scanners/DisputeRuled.js
@@ -69,7 +69,7 @@ describe('DisputeRuled notifications', () => {
       emailTemplateModel: {
         disputeId: TEST_DISPUTE_ID,
         disputeUrl: `${CLIENT_URL}disputes/${TEST_DISPUTE_ID}`,
-        disputeResult: 'Allow'
+        disputeResult: 'Allowed'
       }
     })
     expect(ctx.logger.success).to.have.callCount(1)


### PR DESCRIPTION
Comments from @john-light: 
there are some stray capitalizations "Preliminary Ruling", "Voting" and similarly the button "Appeal Ruling" (where "ruling" should not be title-cased)
we really need to make a writing style guide for Aragon product UIs, so this guidance can be all in one place
but for now I would just suggest the following rules about this: Aragon Court, Dispute #X, and Dashboard or Aragon Court Dashboard are the only words/phrases that need to be capitalized as proper nouns
and the phases ("Appeal phase", "Final ruling" phase, etc) and outcomes ("Refuse to vote", "Block", or "Allow") - but only normal capitalized, not title-cased, and if they are used in the middle of a sentence then put quotes around them to show they are "special" phrases. Bold text can also be used to show the phrase is special e.g. "The final ruling of Dispute #1 is **Refuse to vote**."