### PR TITLE
Services: notification sender fix

### DIFF
--- a/packages/server/src/helpers/session-middleware.js
+++ b/packages/server/src/helpers/session-middleware.js
@@ -1,9 +1,7 @@
 import expressSession from 'express-session'
 import { Session } from '../models/objection'
 
-const MINUTES = 60 * 1000
-const HOURS = 60 * MINUTES
-const DAYS = 24 * HOURS
+import { HOURS, DAYS } from '@aragonone/court-backend-shared/helpers/times'
 const SESSION_MAXAGE = 30 * DAYS
 const SESSION_EXPIRE_INTERVAL = HOURS
 

--- a/packages/server/src/models/objection/User.js
+++ b/packages/server/src/models/objection/User.js
@@ -3,9 +3,7 @@ import UserEmail from './UserEmail'
 import emailClient from '@aragonone/court-backend-shared/helpers/email-client'
 import { generateToken } from '../../helpers/token-manager'
 
-const MINUTES = 60 * 1000
-const HOURS = 60 * MINUTES
-const DAYS = 24 * HOURS
+import { DAYS } from '@aragonone/court-backend-shared/helpers/times'
 const EMAIL_TOKEN_EXPIRES = DAYS
 const EMAIL_TOKEN_OLD = DAYS
 

--- a/packages/server/src/models/objection/UserNotification.js
+++ b/packages/server/src/models/objection/UserNotification.js
@@ -1,6 +1,5 @@
 import BaseModel from './BaseModel'
-const MINUTES = 60 * 1000
-const HOURS = 60 * MINUTES
+import { HOURS } from '@aragonone/court-backend-shared/helpers/times'
 
 export default class UserNotification extends BaseModel {
   static get tableName() {

--- a/packages/server/src/models/objection/UserNotification.js
+++ b/packages/server/src/models/objection/UserNotification.js
@@ -1,4 +1,6 @@
 import BaseModel from './BaseModel'
+const MINUTES = 60 * 1000
+const HOURS = 60 * MINUTES
 
 export default class UserNotification extends BaseModel {
   static get tableName() {
@@ -24,5 +26,11 @@ export default class UserNotification extends BaseModel {
         },
       },
     }
+  }
+
+  static findUnsent() {
+    return this.query()
+      .whereNull('sentAt')
+      .andWhere('createdAt', '>', new Date(Date.now()-HOURS))
   }
 }

--- a/packages/server/src/validators/UserSessionsValidator.js
+++ b/packages/server/src/validators/UserSessionsValidator.js
@@ -1,7 +1,7 @@
 import { utils } from 'ethers'
 import BaseValidator from './BaseValidator'
 
-const MINUTES = 60 * 1000
+import { MINUTES } from '@aragonone/court-backend-shared/helpers/times'
 const SESSION_SIGNATURE_EXPIRES = MINUTES * 10
 
 class UserSessionsValidator  extends BaseValidator {

--- a/packages/services/src/models/notification-scanners/NotificationScannerBaseModel.js
+++ b/packages/services/src/models/notification-scanners/NotificationScannerBaseModel.js
@@ -1,4 +1,5 @@
 const { env: { CLIENT_URL } } = process
+import { MINUTES, HOURS, DAYS } from '@aragonone/court-backend-shared/helpers/times'
 
 export default class NotificationScannerBaseModel {
   async shouldNotifyUser(user) {
@@ -10,9 +11,9 @@ export default class NotificationScannerBaseModel {
       (user.emailVerified || this._sendUnverified)
     )
   }
-  get _MINUTES() { return 60 * 1000 }
-  get _HOURS() { return 60 * this._MINUTES }
-  get _DAYS() { return 24 * this._HOURS }
+  get _MINUTES() { return MINUTES }
+  get _HOURS() { return HOURS }
+  get _DAYS() { return DAYS }
   get _CLIENT_URL() { return CLIENT_URL }
 
   // mandatory methods and functions for extended models

--- a/packages/services/src/workers/notification-sender.js
+++ b/packages/services/src/workers/notification-sender.js
@@ -40,8 +40,14 @@ export async function trySendNotification(ctx, notification) {
     TemplateAlias: scanner.emailTemplateAlias,
     TemplateModel,
   }
-  await emailClient.sendEmailWithTemplate(message)
-  await notification.$query().update({sentAt: new Date()})
-  logger.success(`Notification type ${model} sent for user ${user.address}`)
-  metrics.notificationSent(model)
+  try {
+    await emailClient.sendEmailWithTemplate(message)
+    await notification.$query().update({sentAt: new Date()})
+    logger.success(`Notification type ${model} sent for user ${user.address}`)
+    metrics.notificationSent(model)
+  }
+  catch (error) {
+    metrics.workerError()
+    logger.error(`Could not send notification type ${model} for user ${user.address}`, error)
+  }
 }

--- a/packages/services/src/workers/notification-sender.js
+++ b/packages/services/src/workers/notification-sender.js
@@ -8,7 +8,7 @@ import { accountData } from '../../../../emails/helpers'
  * and sends an associated email
  */
 export default async function (ctx) {
-  const notifications = await UserNotification.query().whereNull('sentAt')
+  const notifications = await UserNotification.findUnsent()
   for (const notification of notifications) {
     await trySendNotification(ctx, notification)
   }

--- a/packages/services/test/integration/notification-scanners/SubscriptionReminder.js
+++ b/packages/services/test/integration/notification-scanners/SubscriptionReminder.js
@@ -14,9 +14,7 @@ const { env: { CLIENT_URL } } = process
 const notificationTypeModel = 'SubscriptionReminder'
 const TEST_ADDR = '0xfc3771B19123F1f0237C737e92645BA6d628e2cB'
 const TEST_EMAIL = 'subscription@reminder.test'
-const MINUTES = 60 * 1000
-const HOURS = 60 * MINUTES
-const DAYS = 24 * HOURS
+import { DAYS } from '@aragonone/court-backend-shared/helpers/times'
 
 
 describe('SubscriptionReminder notifications', () => {

--- a/packages/shared/helpers/times.js
+++ b/packages/shared/helpers/times.js
@@ -1,0 +1,5 @@
+const MINUTES = 60 * 1000
+const HOURS = 60 * MINUTES
+const DAYS = 24 * HOURS
+
+module.exports = { MINUTES, HOURS, DAYS }


### PR DESCRIPTION
For the past 2 days notification sender stopped working because postmark was returning an error for one of the emails. I guess the user verified the email and then deleted afterwards and postmark marked it as non-working.

![image](https://user-images.githubusercontent.com/26359933/84960686-9c62e800-b102-11ea-96a7-dbad027708b2.png)

Just before merging to master I should delete all unsent notifications otherwise users will receive a wave of notifications at the same time.